### PR TITLE
Setup google authentication and its support in tests

### DIFF
--- a/app/models/foreman_google/gce.rb
+++ b/app/models/foreman_google/gce.rb
@@ -1,3 +1,5 @@
+require 'foreman_google/google_compute_adapter'
+
 module ForemanGoogle
   class GCE < ::ComputeResource
     def self.available?
@@ -23,6 +25,7 @@ module ForemanGoogle
     end
 
     def zones
+      client.zones.map(&:name)
     end
     alias_method :available_zones, :zones
 
@@ -76,6 +79,18 @@ module ForemanGoogle
     end
 
     def associated_host(vm)
+    end
+
+    # ----# Google specific #-----
+
+    def google_project_id
+      client.project_id
+    end
+
+    private
+
+    def client
+      @client ||= ForemanGoogle::GoogleComputeAdapter.new(auth_json_string: password)
     end
   end
 end

--- a/foreman_google.gemspec
+++ b/foreman_google.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale,webpack}/**/*'] + ['LICENSE', 'Rakefile', 'README.md', 'package.json']
   s.test_files = Dir['test/**/*'] + Dir['webpack/**/__tests__/*.js']
 
+  s.add_dependency 'google-cloud-compute', '~> 0.2'
   s.add_development_dependency 'rdoc'
 end

--- a/lib/foreman_google/google_compute_adapter.rb
+++ b/lib/foreman_google/google_compute_adapter.rb
@@ -1,0 +1,34 @@
+require 'google-cloud-compute'
+
+module ForemanGoogle
+  class GoogleComputeAdapter
+    def initialize(auth_json_string:)
+      @auth_json = JSON.parse(auth_json_string)
+    end
+
+    def project_id
+      @auth_json['project_id']
+    end
+
+    # ------ RESOURCES ------
+
+    def zones
+      list('zones')
+    end
+
+    private
+
+    def list(resource_name)
+      response = resource_client(resource_name).list(project: project_id).response
+      response.items
+    rescue ::Google::Cloud::Error => e
+      raise Foreman::WrappedException.new(e, 'Cannot list Google resource %s', resource_name)
+    end
+
+    def resource_client(resource_name)
+      ::Google::Cloud::Compute.public_send(resource_name) do |config|
+        config.credentials = @auth_json
+      end
+    end
+  end
+end

--- a/test/factories/gce.rb
+++ b/test/factories/gce.rb
@@ -1,0 +1,28 @@
+FactoryBot.modify do
+  factory :compute_resource do
+    trait :google_gce do
+      transient do
+        project_id { 'coastal-haven-123456' }
+      end
+      provider { 'GCE' }
+      password do
+        # instead of private_key, we hand size of new key to generate
+        # this generate valid mocked key, due to overload of OpenSSL::PKey::RSA.new
+        <<-END_AUTHTOKEN
+        {
+          "type": "service_account",
+          "project_id": "#{project_id}",
+          "private_key_id": "7b1afc23bdfd510c49d827f3151fac94b089b42b",
+          "private_key": 2048,
+          "client_email": "xxxxxxx-compute@developer.gserviceaccount.com",
+          "client_id": "111235611116543210000",
+          "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+          "token_uri": "https://oauth2.googleapis.com/token",
+          "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+          "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/552404852006-compute%40developer.gserviceaccount.com"
+        }
+        END_AUTHTOKEN
+      end
+    end
+  end
+end

--- a/test/fixtures/zones.json
+++ b/test/fixtures/zones.json
@@ -1,0 +1,1750 @@
+{
+  "id": "projects/coastal-haven-123456/zones",
+  "items": [
+    {
+      "id": "2231",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-east1-b",
+      "description": "us-east1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-east1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2233",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-east1-c",
+      "description": "us-east1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-east1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2234",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-east1-d",
+      "description": "us-east1-d",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-east1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-d",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2272",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-east4-c",
+      "description": "us-east4-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-east4",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east4-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2271",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-east4-b",
+      "description": "us-east4-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-east4",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east4-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2270",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-east4-a",
+      "description": "us-east4-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-east4",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east4-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2002",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-central1-c",
+      "description": "us-central1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-central1-c",
+      "availableCpuPlatforms": [
+        "Intel Ice Lake",
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2000",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-central1-a",
+      "description": "us-central1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-central1-a",
+      "availableCpuPlatforms": [
+        "Intel Ice Lake",
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2004",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-central1-f",
+      "description": "us-central1-f",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-central1-f",
+      "availableCpuPlatforms": [
+        "Intel Ice Lake",
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2001",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-central1-b",
+      "description": "us-central1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-central1-b",
+      "availableCpuPlatforms": [
+        "Intel Ice Lake",
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2211",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west1-b",
+      "description": "us-west1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2212",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west1-c",
+      "description": "us-west1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2210",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west1-a",
+      "description": "us-west1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west1-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2342",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west4-a",
+      "description": "europe-west4-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west4",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west4-a",
+      "availableCpuPlatforms": [
+        "Intel Ice Lake",
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2341",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west4-b",
+      "description": "europe-west4-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west4",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west4-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2340",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west4-c",
+      "description": "europe-west4-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west4",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west4-c",
+      "availableCpuPlatforms": [
+        "Intel Ice Lake",
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2101",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west1-b",
+      "description": "europe-west1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2104",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west1-d",
+      "description": "europe-west1-d",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west1-d",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2103",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west1-c",
+      "description": "europe-west1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2300",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west3-c",
+      "description": "europe-west3-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west3",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west3-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2301",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west3-a",
+      "description": "europe-west3-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west3",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west3-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2302",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west3-b",
+      "description": "europe-west3-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west3",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west3-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2292",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west2-c",
+      "description": "europe-west2-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west2-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2291",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west2-b",
+      "description": "europe-west2-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west2-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2290",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west2-a",
+      "description": "europe-west2-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west2-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2221",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-east1-b",
+      "description": "asia-east1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-east1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-east1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2220",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-east1-a",
+      "description": "asia-east1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-east1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-east1-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2222",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-east1-c",
+      "description": "asia-east1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-east1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-east1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2261",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-southeast1-b",
+      "description": "asia-southeast1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-southeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-southeast1-b",
+      "availableCpuPlatforms": [
+        "Intel Ice Lake",
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2260",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-southeast1-a",
+      "description": "asia-southeast1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-southeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-southeast1-a",
+      "availableCpuPlatforms": [
+        "Intel Ice Lake",
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2262",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-southeast1-c",
+      "description": "asia-southeast1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-southeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-southeast1-c",
+      "availableCpuPlatforms": [
+        "Intel Ice Lake",
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2251",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-northeast1-b",
+      "description": "asia-northeast1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-northeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-northeast1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2252",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-northeast1-c",
+      "description": "asia-northeast1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-northeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-northeast1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2250",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-northeast1-a",
+      "description": "asia-northeast1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-northeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-northeast1-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2322",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-south1-c",
+      "description": "asia-south1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-south1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-south1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2320",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-south1-b",
+      "description": "asia-south1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-south1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-south1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2321",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-south1-a",
+      "description": "asia-south1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-south1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-south1-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2282",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "australia-southeast1-b",
+      "description": "australia-southeast1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/australia-southeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/australia-southeast1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2280",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "australia-southeast1-c",
+      "description": "australia-southeast1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/australia-southeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/australia-southeast1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2281",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "australia-southeast1-a",
+      "description": "australia-southeast1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/australia-southeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/australia-southeast1-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2311",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "southamerica-east1-b",
+      "description": "southamerica-east1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/southamerica-east1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/southamerica-east1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2312",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "southamerica-east1-c",
+      "description": "southamerica-east1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/southamerica-east1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/southamerica-east1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2310",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "southamerica-east1-a",
+      "description": "southamerica-east1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/southamerica-east1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/southamerica-east1-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2372",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-east2-a",
+      "description": "asia-east2-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-east2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-east2-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2371",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-east2-b",
+      "description": "asia-east2-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-east2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-east2-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2370",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-east2-c",
+      "description": "asia-east2-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-east2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-east2-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": true,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2392",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-northeast2-a",
+      "description": "asia-northeast2-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-northeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-northeast2-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2390",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-northeast2-b",
+      "description": "asia-northeast2-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-northeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-northeast2-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2391",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-northeast2-c",
+      "description": "asia-northeast2-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-northeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-northeast2-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2410",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-northeast3-a",
+      "description": "asia-northeast3-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-northeast3",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-northeast3-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2412",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-northeast3-b",
+      "description": "asia-northeast3-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-northeast3",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-northeast3-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2411",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-northeast3-c",
+      "description": "asia-northeast3-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-northeast3",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-northeast3-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2470",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-south2-a",
+      "description": "asia-south2-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-south2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-south2-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2472",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-south2-b",
+      "description": "asia-south2-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-south2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-south2-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2471",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-south2-c",
+      "description": "asia-south2-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-south2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-south2-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2440",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-southeast2-a",
+      "description": "asia-southeast2-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-southeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-southeast2-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2442",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-southeast2-b",
+      "description": "asia-southeast2-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-southeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-southeast2-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2441",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "asia-southeast2-c",
+      "description": "asia-southeast2-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/asia-southeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/asia-southeast2-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2480",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "australia-southeast2-a",
+      "description": "australia-southeast2-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/australia-southeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/australia-southeast2-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2482",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "australia-southeast2-b",
+      "description": "australia-southeast2-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/australia-southeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/australia-southeast2-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2481",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "australia-southeast2-c",
+      "description": "australia-southeast2-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/australia-southeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/australia-southeast2-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2452",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-central2-a",
+      "description": "europe-central2-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-central2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-central2-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2450",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-central2-b",
+      "description": "europe-central2-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-central2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-central2-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2451",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-central2-c",
+      "description": "europe-central2-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-central2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-central2-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2352",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-north1-a",
+      "description": "europe-north1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-north1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-north1-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2350",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-north1-b",
+      "description": "europe-north1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-north1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-north1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2351",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-north1-c",
+      "description": "europe-north1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-north1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-north1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2382",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west6-a",
+      "description": "europe-west6-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west6",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west6-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2380",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west6-b",
+      "description": "europe-west6-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west6",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west6-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2381",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "europe-west6-c",
+      "description": "europe-west6-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west6",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/europe-west6-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2330",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "northamerica-northeast1-a",
+      "description": "northamerica-northeast1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/northamerica-northeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/northamerica-northeast1-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2331",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "northamerica-northeast1-b",
+      "description": "northamerica-northeast1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/northamerica-northeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/northamerica-northeast1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2332",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "northamerica-northeast1-c",
+      "description": "northamerica-northeast1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/northamerica-northeast1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/northamerica-northeast1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2461",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "northamerica-northeast2-a",
+      "description": "northamerica-northeast2-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/northamerica-northeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/northamerica-northeast2-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2460",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "northamerica-northeast2-b",
+      "description": "northamerica-northeast2-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/northamerica-northeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/northamerica-northeast2-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2462",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "northamerica-northeast2-c",
+      "description": "northamerica-northeast2-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/northamerica-northeast2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/northamerica-northeast2-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2490",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "southamerica-west1-a",
+      "description": "southamerica-west1-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/southamerica-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/southamerica-west1-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2491",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "southamerica-west1-b",
+      "description": "southamerica-west1-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/southamerica-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/southamerica-west1-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2492",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "southamerica-west1-c",
+      "description": "southamerica-west1-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/southamerica-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/southamerica-west1-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2362",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west2-a",
+      "description": "us-west2-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west2-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2361",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west2-b",
+      "description": "us-west2-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west2-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2360",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west2-c",
+      "description": "us-west2-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west2",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west2-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2420",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west3-a",
+      "description": "us-west3-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west3",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west3-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Haswell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2421",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west3-b",
+      "description": "us-west3-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west3",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west3-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2422",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west3-c",
+      "description": "us-west3-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west3",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west3-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "Intel Sandy Bridge"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2431",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west4-a",
+      "description": "us-west4-a",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west4",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west4-a",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2432",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west4-b",
+      "description": "us-west4-b",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west4",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west4-b",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    },
+    {
+      "id": "2430",
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "name": "us-west4-c",
+      "description": "us-west4-c",
+      "status": "UP",
+      "region": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/us-west4",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-west4-c",
+      "availableCpuPlatforms": [
+        "Intel Cascade Lake",
+        "Intel Skylake",
+        "Intel Broadwell",
+        "Intel Ivy Bridge",
+        "AMD Milan",
+        "AMD Rome"
+      ],
+      "supportsPzs": false,
+      "kind": "compute#zone"
+    }
+  ],
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones",
+  "kind": "compute#zoneList"
+}

--- a/test/test_google_helper.rb
+++ b/test/test_google_helper.rb
@@ -1,0 +1,17 @@
+# This calls the main test_helper in Foreman-core
+require 'test_helper'
+
+# Add plugin to FactoryBot's paths
+FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
+FactoryBot.reload
+
+class GoogleTestCase < ActiveSupport::TestCase
+  let(:google_access_token) { 'ya29.c.stubbed_token' }
+  let(:gce_cr) { FactoryBot.create(:compute_resource, :google_gce) }
+  let(:google_project_id) { gce_cr.google_project_id }
+  let(:gauth_json) { gce_cr.password }
+
+  setup do
+    ::Signet::OAuth2::Client.any_instance.stubs(fetch_access_token!: google_access_token)
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -1,6 +1,0 @@
-# This calls the main test_helper in Foreman-core
-require 'test_helper'
-
-# Add plugin to FactoryBot's paths
-FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
-FactoryBot.reload

--- a/test/unit/foreman_google/google_compute_adapter_test.rb
+++ b/test/unit/foreman_google/google_compute_adapter_test.rb
@@ -1,0 +1,37 @@
+require 'test_google_helper'
+require 'foreman_google/google_compute_adapter'
+
+require 'google/cloud/compute/v1/zones/credentials'
+module ForemanGoogle
+  class GoogleComputeAdapterTest < GoogleTestCase
+    subject { ForemanGoogle::GoogleComputeAdapter.new(auth_json_string: gauth_json) }
+
+    describe 'authentication' do
+      it 'passes the auth json to the service client' do
+        credentials = stub(client: stub(apply: { authorization: "Bearer #{google_access_token}" }))
+        ::Google::Cloud::Compute::V1::Zones::Credentials.expects(:new).with(JSON.parse(gauth_json), has_key(:scope)).returns(credentials)
+        stub_request(:get, 'https://compute.googleapis.com/compute/v1/projects/coastal-haven-123456/zones')
+          .to_return(body: '{
+            "id": "projects/coastal-haven-123456/zones",
+            "items": [],
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones",
+            "kind": "compute#zoneList"
+          }')
+        subject.zones
+      end
+    end
+
+    describe '#zones' do
+      setup do
+        stub_request(:get, 'https://compute.googleapis.com/compute/v1/projects/coastal-haven-123456/zones')
+          .to_return(body: File.read(File.join(__dir__, '..', '..', 'fixtures', 'zones.json')))
+      end
+
+      it 'show zones' do
+        zones = subject.zones
+        value(zones.first.name).must_be_kind_of(String)
+        value(zones.first.description).must_be_kind_of(String)
+      end
+    end
+  end
+end

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -1,7 +1,0 @@
-require 'test_plugin_helper'
-
-class ForemanGoogleTest < ActiveSupport::TestCase
-  test 'the truth' do
-    assert true
-  end
-end


### PR DESCRIPTION
Setup a way to initialize the google client.
Adding google-cloud-compute as dependency, this is superior client to google-apis-*

Create the wiring for the auth to be passed to the client and stub the auth in tests.