### PR TITLE
Temporarily prepend core paths

### DIFF
--- a/app/controllers/concerns/foreman_google/temporary_prepend_path.rb
+++ b/app/controllers/concerns/foreman_google/temporary_prepend_path.rb
@@ -1,0 +1,16 @@
+module ForemanGoogle
+  # This module prepends core paths so view for gce takes precedence over core ones
+  # This module NEEDS to get deleted once the core support for gce is dropped.
+  # or this plugin is merged to core
+  module TemporaryPrependPath
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :prepare_views
+    end
+
+    def prepare_views
+      prepend_view_path ForemanGoogle::Engine.root.join('app', 'views')
+    end
+  end
+end

--- a/lib/foreman_google/engine.rb
+++ b/lib/foreman_google/engine.rb
@@ -22,6 +22,7 @@ module ForemanGoogle
 
     # Include concerns in this config.to_prepare block
     config.to_prepare do
+      ::ComputeResourcesController.include ForemanGoogle::TemporaryPrependPath
     rescue StandardError => e
       Rails.logger.warn "ForemanGoogle: skipping engine hook (#{e})"
     end


### PR DESCRIPTION
To serve our CR snippets from plugin and not core, we need to prepend paths.
This should be resolved once support for GCE is dropped from core, or we merge this plugin to core

This Aint perfect, but allows the two CRs named the same to coexist (namly allows our CR to override the core CR)