### PR TITLE
Compute Resource and Virtual machines index

### DIFF
--- a/app/lib/google_cloud_compute/compute_collection.rb
+++ b/app/lib/google_cloud_compute/compute_collection.rb
@@ -1,0 +1,23 @@
+module GoogleCloudCompute
+  class ComputeCollection
+    include Enumerable
+
+    def initialize(client, zone, attrs)
+      instances = client.instances(zone, attrs)
+      @virtual_machines = instances.map do |vm|
+        ForemanGoogle::GoogleCompute.new client: client,
+          zone: zone,
+          identity: vm.id,
+          instance: vm
+      end
+    end
+
+    def each(&block)
+      @virtual_machines.each(&block)
+    end
+
+    def all(_opts = {})
+      @virtual_machines
+    end
+  end
+end

--- a/app/models/foreman_google/gce.rb
+++ b/app/models/foreman_google/gce.rb
@@ -117,6 +117,10 @@ module ForemanGoogle
       client.images(filter: filter)
     end
 
+    def vms(attrs = {})
+      GoogleCloudCompute::ComputeCollection.new(client, zone, attrs)
+    end
+
     # ----# Google specific #-----
 
     def google_project_id

--- a/app/views/compute_resources_vms/index/_gce.html.erb
+++ b/app/views/compute_resources_vms/index/_gce.html.erb
@@ -1,0 +1,26 @@
+<thead>
+  <tr>
+    <th><%= _('Name') %></th>
+    <th><%= _('Type') %></th>
+    <th><%= _('State') %></th>
+    <th><%= _('Actions') %></th>
+  </tr>
+</thead>
+<tbody>
+  <% @vms.each do |vm| %>
+    <%
+      view_path = hash_for_compute_resource_vm_path(compute_resource_id: @compute_resource, id: vm.identity).merge(auth_object: @compute_resource.id, auth_action: 'view', authorizer: authorizer)
+      delete_link = display_delete_if_authorized(hash_for_compute_resource_vm_path(compute_resource_id: @compute_resource, id: vm.identity).merge(auth_object: @compute_resource, authorizer: authorizer))
+    %>
+    <tr>
+      <td><%= link_to_if_authorized vm.name, view_path %></td>
+      <td><%= vm.pretty_machine_type %></td>
+      <td><%= vm.status.downcase %></td>
+      <td>
+        <%= action_buttons(vm_power_action(vm, authorizer),
+                           vm_import_action(vm),vm_associate_link(vm),
+                           delete_link) %>
+      </td>
+    </tr>
+  <% end %>
+</tbody>

--- a/lib/foreman_google/google_compute_adapter.rb
+++ b/lib/foreman_google/google_compute_adapter.rb
@@ -24,6 +24,10 @@ module ForemanGoogle
       get('instances', instance: instance_identity, zone: zone)
     end
 
+    def instances(zone, **attrs)
+      list('instances', zone: zone, **attrs)
+    end
+
     def zones
       list('zones')
     end

--- a/test/fixtures/instance_list.json
+++ b/test/fixtures/instance_list.json
@@ -1,0 +1,86 @@
+{
+  "kind": "compute#instanceList",
+  "id": "projects/coastal-haven-123456/zones/us-east1-b/instances",
+  "items": [
+    {
+      "kind": "compute#instance",
+      "id": "123",
+      "creationTimestamp": "2022-03-30T04:59:13.453-07:00",
+      "name": "foreman-test-google1648641548",
+      "tags": {
+        "fingerprint": "42WmSpB8rSM="
+      },
+      "machineType": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-b/machineTypes/e2-micro",
+      "status": "TERMINATED",
+      "zone": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-b",
+      "networkInterfaces": [
+        {
+          "kind": "compute#networkInterface",
+          "network": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/global/networks/default",
+          "subnetwork": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/regions/europe-west3/subnetworks/default",
+          "networkIP": "10.156.0.15",
+          "name": "nic0",
+          "fingerprint": "TJa5cxJEqkU=",
+          "stackType": "IPV4_ONLY"
+        }
+      ],
+      "disks": [
+        {
+          "kind": "compute#attachedDisk",
+          "type": "PERSISTENT",
+          "mode": "READ_WRITE",
+          "source": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-b/disks/foreman-test-google1648641548-disk1",
+          "deviceName": "persistent-disk-0",
+          "index": 0,
+          "boot": true,
+          "autoDelete": true,
+          "licenses": [
+            "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/licenses/centos-stream"
+          ],
+          "interface": "SCSI",
+          "guestOsFeatures": [
+            {
+              "type": "UEFI_COMPATIBLE"
+            },
+            {
+              "type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "type": "SEV_CAPABLE"
+            },
+            {
+              "type": "GVNIC"
+            }
+          ],
+          "diskSizeGb": "23"
+        }
+      ],
+      "metadata": {
+        "kind": "compute#metadata",
+        "fingerprint": "YazRB9ehpGM="
+      },
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-b/instances/foreman-test-google1648641548",
+      "scheduling": {
+        "onHostMaintenance": "MIGRATE",
+        "automaticRestart": true,
+        "preemptible": false
+      },
+      "cpuPlatform": "Unknown CPU Platform",
+      "labelFingerprint": "42WmSpB8rSM=",
+      "startRestricted": false,
+      "deletionProtection": false,
+      "shieldedInstanceConfig": {
+        "enableSecureBoot": false,
+        "enableVtpm": true,
+        "enableIntegrityMonitoring": true
+      },
+      "shieldedInstanceIntegrityPolicy": {
+        "updateAutoLearnPolicy": true
+      },
+      "fingerprint": "kDkIG75oL1k=",
+      "lastStartTimestamp": "2022-04-07T06:09:42.109-07:00",
+      "lastStopTimestamp": "2022-04-07T06:52:58.005-07:00"
+    }
+  ],
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-b/instances"
+}

--- a/test/models/foreman_google/gce_test.rb
+++ b/test/models/foreman_google/gce_test.rb
@@ -27,5 +27,21 @@ module ForemanGoogle
         value { subject.find_vm_by_uuid('non-existing-name-or-id') }.must_raise(Foreman::WrappedException)
       end
     end
+
+    describe '#vms' do
+      let(:instances) { [OpenStruct.new(name: 'instance1'), OpenStruct.new(name: 'instance2')] }
+
+      setup do
+        service.expects(:instances).returns(instances)
+      end
+
+      it 'iteration over the vms array' do
+        subject.vms.each_with_index { |instance, i| assert instance.name, instances[i].name }
+      end
+
+      it 'all method' do
+        subject.vms.each_with_index { |instance, i| assert instance.name, instances[i].name }
+      end
+    end
   end
 end

--- a/test/models/foreman_google/google_compute_test.rb
+++ b/test/models/foreman_google/google_compute_test.rb
@@ -151,5 +151,12 @@ module ForemanGoogle
         assert_nil cr.metadata
       end
     end
+
+    it '#pretty_machine_type' do
+      instance = OpenStruct.new(machine_type: 'https://www.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-b/machineTypes/e2-micro')
+      cr = ForemanGoogle::GoogleCompute.new(client: client, zone: zone, instance: instance)
+
+      assert_equal cr.pretty_machine_type, 'e2-micro'
+    end
   end
 end

--- a/test/unit/foreman_google/google_compute_adapter_test.rb
+++ b/test/unit/foreman_google/google_compute_adapter_test.rb
@@ -34,6 +34,19 @@ module ForemanGoogle
       end
     end
 
+    describe '#instances' do
+      setup do
+        stub_request(:get, 'https://compute.googleapis.com/compute/v1/projects/coastal-haven-123456/zones/us-east1-b/instances')
+          .to_return(body: File.read(File.join(__dir__, '..', '..', 'fixtures', 'instance_list.json')))
+      end
+
+      it 'gets instance by id' do
+        instances = subject.instances('us-east1-b')
+        value(instances[0]).must_be_kind_of(Google::Cloud::Compute::V1::Instance)
+        value(instances[0].id).must_equal(123)
+      end
+    end
+
     describe '#zones' do
       setup do
         stub_request(:get, 'https://compute.googleapis.com/compute/v1/projects/coastal-haven-123456/zones')


### PR DESCRIPTION
Missing methods for VMs index on compute resource detail.
Now it is possible to list the VMS associated to the CR
and power on/of the VM.