### PR TITLE
Views and helpers refactoring

### DIFF
--- a/app/lib/google_extensions/attached_disk.rb
+++ b/app/lib/google_extensions/attached_disk.rb
@@ -1,7 +1,6 @@
 module GoogleExtensions
   module AttachedDisk
     def persisted?
-      type == 'PERSISTENT'
     end
 
     def id

--- a/app/lib/google_extensions/attached_disk.rb
+++ b/app/lib/google_extensions/attached_disk.rb
@@ -1,0 +1,13 @@
+module GoogleExtensions
+  module AttachedDisk
+    def persisted?
+      type == 'PERSISTENT'
+    end
+
+    def id
+    end
+
+    def _delete
+    end
+  end
+end

--- a/app/views/compute_resources/form/_gce.html.erb
+++ b/app/views/compute_resources/form/_gce.html.erb
@@ -1,7 +1,10 @@
+<%= http_proxy_field f %>
+
 <%= textarea_f f, :password, :label => _("JSON key"),
               :help_inline => file_field(:password, :json, accept: "application/JSON", onchange: 'tfm.gce.jsonLoader(this)'),
               :id => 'gce_json', :class => 'col-md-8' %>
 
 <% zones = f.object.zones rescue [] %>
+
 <%= selectable_f(f, :zone, zones, {}, {:label => _('Zone'), :disabled => zones.empty?,
                  :help_inline_permanent => load_button_f(f, zones.any?, _("Load Zones")) }) %>

--- a/app/views/compute_resources/show/_gce.html.erb
+++ b/app/views/compute_resources/show/_gce.html.erb
@@ -1,8 +1,0 @@
-<tr>
-  <td><%= _("Project id") %></td>
-  <td><%= @compute_resource.google_project_id %></td>
-</tr>
-<tr>
-  <td><%= _("Zone") %></td>
-  <td><%= @compute_resource.zone %></td>
-</tr>

--- a/app/views/compute_resources_vms/form/gce/_base.html.erb
+++ b/app/views/compute_resources_vms/form/gce/_base.html.erb
@@ -1,0 +1,18 @@
+<%= select_f f, :machine_type, compute_resource.machine_types, :name, :name,
+			{ :selected => f.object.pretty_machine_type },
+			{ :label => _('Machine type'), :label_size => "col-md-2" } %>
+
+<% if controller_name != "compute_attributes" %>
+	<%
+	  arch ||= nil ; os ||= nil
+	  images = possible_images(compute_resource, arch, os)
+	%>
+	<div id='image_selection'>
+	  <%= select_f f, :image_id, images, :uuid, :name,
+	               { :include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image') },
+	               { :disabled => images.empty?, :label => _('Image'), :label_size => "col-md-2" } %>
+	</div>
+<% end %>
+
+<%= selectable_f f, :network, compute_resource.networks, {}, :label => _('Network'), :label_size => "col-md-2" %>
+<%= checkbox_f f, :associate_external_ip, :label => _('Associate Ephemeral External IP'), :label_size => "col-md-2" %>

--- a/app/views/compute_resources_vms/form/gce/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/gce/_volume.html.erb
@@ -1,0 +1,5 @@
+<%
+  # For backwards compatibility, Fog has :size_gb, Google has :disk_size_gb
+  field_name = f.object.class == Google::Cloud::Compute::V1::AttachedDisk ? :disk_size_gb : :size_gb
+%>
+<%= text_f f, field_name, class: "col-md-2", label: _("Size (GB)"), label_size: "col-md-2", onchange: 'tfm.computeResource.capacityEdit(this)' %>

--- a/lib/foreman_google/engine.rb
+++ b/lib/foreman_google/engine.rb
@@ -23,7 +23,12 @@ module ForemanGoogle
 
     # Include concerns in this config.to_prepare block
     config.to_prepare do
+      require 'google/cloud/compute/v1'
+      Google::Cloud::Compute::V1::AttachedDisk.include GoogleExtensions::AttachedDisk
+
       ::ComputeResourcesController.include ForemanGoogle::TemporaryPrependPath
+      ::ComputeResourcesVmsController.include ForemanGoogle::TemporaryPrependPath
+      ::HostsController.include ForemanGoogle::TemporaryPrependPath
     rescue StandardError => e
       Rails.logger.warn "ForemanGoogle: skipping engine hook (#{e})"
     end


### PR DESCRIPTION
**Checked views**
```
app/views/compute_resources/form/_gce.html.erb
app/views/compute_resources/show/_gce.html.erb
app/views/compute_resources_vms/index/_gce.html.erb
app/views/compute_resources_vms/show/_gce.html.erb
app/views/compute_resources_vms/form/gce/_base.html.erb
app/views/compute_resources_vms/form/gce/_volume.html.erb
```

**Notes**
* Importing host from CR still doesn't work but at least you can display the form without errors
* Same goes for creating new host
* I hope I catch all the views, but I won't bet my money on this
* With these changes old core code for Google resource can be tested together with the plugin's new resource
* This way you can have two compute resources at one time:
```
rails console

User.current = User.find_by(login: 'admin')

ComputeResource.create(name: 'gce_core', url: 'zone', type: 'Foreman::Model::GCE', attrs: {:email=>"your-email", :key_path=>"path-to-key-file", :project=>"your-project"})

ComputeResource.create(name: 'gce_plugin', url: 'zone', type: 'ForemanGoogle::GCE', password: File.read('path-to-key-file'))
```