### PR TITLE
Host console

### DIFF
--- a/app/lib/foreman_google/google_compute_adapter.rb
+++ b/app/lib/foreman_google/google_compute_adapter.rb
@@ -78,6 +78,10 @@ module ForemanGoogle
       end
     end
 
+    def serial_port_output(zone, instance_identity)
+      manage_instance(:get_serial_port_output, zone: zone, instance: instance_identity)
+    end
+
     private
 
     def list(resource_name, **opts)

--- a/app/models/foreman_google/gce.rb
+++ b/app/models/foreman_google/gce.rb
@@ -111,6 +111,17 @@ module ForemanGoogle
     end
 
     def console(uuid)
+      vm = find_vm_by_uuid(uuid)
+
+      if vm.ready?
+        {
+          'output' => vm.serial_port_output, 'timestamp' => Time.now.utc,
+          :type => 'log', :name => vm.name
+        }
+      else
+        raise ::Foreman::Exception,
+          N_('console is not available at this time because the instance is powered off')
+      end
     end
 
     def associated_host(vm)

--- a/app/models/foreman_google/google_compute.rb
+++ b/app/models/foreman_google/google_compute.rb
@@ -126,6 +126,10 @@ module ForemanGoogle
     def volumes_attributes=(_attrs)
     end
 
+    def serial_port_output
+      @client.serial_port_output(@zone, @identity)&.contents
+    end
+
     private
 
     def load


### PR DESCRIPTION
* Implement console output for the host
* Move GoogleComputeAdapter to app/lib
  (fix autoloading issue after 6.1 Rails update)