### PR TITLE
Balanced persistent disks

### DIFF
--- a/app/lib/google_extensions/attached_disk.rb
+++ b/app/lib/google_extensions/attached_disk.rb
@@ -10,7 +10,7 @@ module GoogleExtensions
     end
 
     def insert_attrs
-      attrs = { name: device_name, size_gb: disk_size_gb }
+      attrs = { name: device_name, size_gb: disk_size_gb, type: type }
       attrs[:source_image] = source if source.present?
       attrs
     end

--- a/app/models/foreman_google/google_compute.rb
+++ b/app/models/foreman_google/google_compute.rb
@@ -169,8 +169,10 @@ module ForemanGoogle
       image
     end
 
+    # rubocop:disable Metrics/AbcSize
     def construct_volumes(image_id, volumes = [])
-      return [Google::Cloud::Compute::V1::AttachedDisk.new(disk_size_gb: 20)] if volumes.empty?
+      type = "projects/#{@client.project_id}/zones/#{@zone}/diskTypes/pd-balanced"
+      return [Google::Cloud::Compute::V1::AttachedDisk.new(disk_size_gb: 20, type: type)] if volumes.empty?
 
       image = load_image(image_id)
 
@@ -178,12 +180,13 @@ module ForemanGoogle
         name = "#{@name}-disk#{i + 1}"
         size = (vol_attrs[:size_gb] || vol_attrs[:disk_size_gb]).to_i
 
-        Google::Cloud::Compute::V1::AttachedDisk.new(device_name: name, disk_size_gb: size)
+        Google::Cloud::Compute::V1::AttachedDisk.new(device_name: name, disk_size_gb: size, type: type)
       end
 
       attached_disks.first.source = image&.self_link if image&.self_link
       attached_disks
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Note - GCE only supports cloud-init for Container Optimized images and
     # for custom images with cloud-init setup

--- a/test/models/foreman_google/google_compute_test.rb
+++ b/test/models/foreman_google/google_compute_test.rb
@@ -114,9 +114,9 @@ module ForemanGoogle
 
       it 'no volumes' do
         cr = ForemanGoogle::GoogleCompute.new(client: client, zone: zone)
-        volumes = [Google::Cloud::Compute::V1::AttachedDisk.new(disk_size_gb: 20)]
 
-        assert_equal cr.volumes, volumes
+        assert_equal 20, cr.volumes.first.disk_size_gb
+        assert_equal 'projects/project_id/zones/zone-1/diskTypes/pd-balanced', cr.volumes.first.type
       end
 
       it 'without image_id' do


### PR DESCRIPTION
Create new disks same way as in UI, use type `pd-balanced` (SSD)
instead of `pd-standard type` (HDD)