### PR TITLE
Fixes #35986 - :project & :email API params

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/compute_resource_extension.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/compute_resource_extension.rb
@@ -7,11 +7,7 @@ module Foreman
         class_methods do
           def compute_resource_params_filter
             super.tap do |filter|
-              filter.permit :email,
-                :key_pair,
-                :key_path,
-                :project,
-                :zone
+              filter.permit :key_path, :zone
             end
           end
         end

--- a/app/controllers/foreman_google/api/v2/apipie_extensions.rb
+++ b/app/controllers/foreman_google/api/v2/apipie_extensions.rb
@@ -8,6 +8,8 @@ module ForemanGoogle
           param :compute_resource, Hash do
             param :key_path, String, desc: N_('Certificate path, for GCE only')
             param :zone, String, desc: N_('Zone, for GCE only')
+            param :project, String, desc: N_('Deprecated, project is automatically loaded from the JSON file. For GCE only')
+            param :email, String, desc: N_('Deprecated, email is automatically loaded from the JSON file. For GCE only')
           end
         end
       end

--- a/app/controllers/foreman_google/api/v2/compute_resources_extensions.rb
+++ b/app/controllers/foreman_google/api/v2/compute_resources_extensions.rb
@@ -7,6 +7,7 @@ module ForemanGoogle
         # rubocop:disable Rails/LexicallyScopedActionFilter
         included do
           before_action :read_key, only: [:create]
+          before_action :deprecated_params, only: [:create]
         end
         # rubocop:enable Rails/LexicallyScopedActionFilter
 
@@ -15,6 +16,19 @@ module ForemanGoogle
         def read_key
           return unless compute_resource_params['provider'] == 'GCE'
           params[:compute_resource][:password] = File.read(params['compute_resource'].delete('key_path'))
+        end
+
+        def deprecated_params
+          return unless compute_resource_params['provider'] == 'GCE'
+
+          if compute_resource_params['email']
+            msg = _('The email parameter is deprecated, value is automatically loaded from the JSON file')
+            Foreman::Deprecation.api_deprecation_warning(msg)
+          end
+
+          return unless compute_resource_params['project']
+          msg = _('The project parameter is deprecated, value is automatically loaded from the JSON file')
+          Foreman::Deprecation.api_deprecation_warning(msg)
         end
       end
     end


### PR DESCRIPTION
* remove obsolete params from the compute_resource_extension.rb
* Put back :project & :email API params, but mark them as deprecated with information about new approach (loading values from .json file)