### PR TITLE
Bump theforeman/builder to 12+

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@sheerun/mutationobserver-shim": "^0.3.3",
-    "@theforeman/builder": "^10.0",
+    "@theforeman/builder": ">= 12.0.1",
     "@theforeman/eslint-plugin-foreman": "^10.0",
     "@theforeman/find-foreman": "^10.0",
     "@theforeman/stories": "^10.0",


### PR DESCRIPTION
The current version of foreman_google will not build in our environment without this change.