### PR TITLE
Zeitwerk & Google's API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec name: 'foreman_google'
-
-gem 'theforeman-rubocop', '~> 0.1.1'

--- a/app/lib/foreman_google/google_compute_adapter.rb
+++ b/app/lib/foreman_google/google_compute_adapter.rb
@@ -1,5 +1,3 @@
-require 'google-cloud-compute'
-
 # rubocop:disable Rails/SkipsModelValidations, Metrics/ClassLength
 module ForemanGoogle
   class GoogleComputeAdapter

--- a/app/models/foreman_google/google_compute.rb
+++ b/app/models/foreman_google/google_compute.rb
@@ -1,5 +1,3 @@
-require 'google/apis/compute_v1'
-
 module ForemanGoogle
   class GoogleCompute
     attr_reader :identity, :name, :hostname, :creation_timestamp, :machine_type, :network_interfaces, :volumes,

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,0 +1,3 @@
+require 'google/apis/compute_v1'
+require 'google/cloud/compute/v1'
+require 'google-cloud-compute'

--- a/foreman_google.gemspec
+++ b/foreman_google.gemspec
@@ -16,7 +16,13 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale,webpack}/**/*'] + ['LICENSE', 'Rakefile', 'README.md', 'package.json']
   s.test_files = Dir['test/**/*'] + Dir['webpack/**/__tests__/*.js']
 
-  s.add_dependency 'google-apis-compute_v1', '~> 0.14'
-  s.add_dependency 'google-cloud-compute', '~> 0.2'
+  # Pin Google versions to avoid breaking changes
+  # Never versions with google-protobuf > 3.25.4
+  # are failing with `undefined method 'build'` error
+  s.add_dependency 'google-apis-compute_v1', '0.54.0'
+  s.add_dependency 'google-cloud-compute', '0.5.0'
+  s.add_dependency 'google-protobuf', '3.24.3'
+
   s.add_development_dependency 'rdoc'
+  s.add_development_dependency 'theforeman-rubocop', '~> 0.1.1'
 end

--- a/lib/foreman_google/engine.rb
+++ b/lib/foreman_google/engine.rb
@@ -24,8 +24,6 @@ module ForemanGoogle
 
     # Include concerns in this config.to_prepare block
     config.to_prepare do
-      require 'google/cloud/compute/v1'
-
       ::Host::Managed.include ForemanGoogle::HostManagedExtensions
       ::Api::V2::ComputeResourcesController.include ForemanGoogle::Api::V2::ComputeResourcesExtensions
       ::Api::V2::ComputeResourcesController.include ForemanGoogle::Api::V2::ApipieExtensions


### PR DESCRIPTION
1. Require all Google gems in the initializer
2. Pin Google dependencies to specific versions
   due to an undefined method 'build' error in newer versions
3. Move Rubocop from Gemfile to Gemspec