### PR TITLE
Pass keyword arguments correctly (#9332)

### DIFF
--- a/app/lib/google_cloud_compute/compute_collection.rb
+++ b/app/lib/google_cloud_compute/compute_collection.rb
@@ -2,8 +2,8 @@ module GoogleCloudCompute
   class ComputeCollection
     include Enumerable
 
-    def initialize(client, zone, attrs)
-      instances = client.instances(zone, attrs)
+    def initialize(client, zone, attrs = {})
+      instances = client.instances(zone, **attrs)
       @virtual_machines = instances.map do |vm|
         ForemanGoogle::GoogleCompute.new client: client,
           zone: zone,


### PR DESCRIPTION
In Ruby 3.0 keyword arguments are handled separate from positional arguments[1]. This uses kwargs and passes it along.

[1]: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/