### PR TITLE
Remove rhel-8 target from Packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -29,11 +29,6 @@ jobs:
     job: copr_build
     trigger: pull_request
     targets:
-      rhel-8:
-        additional_modules: "foreman-devel:el8"
-        additional_repos:
-          - https://yum.theforeman.org/releases/nightly/el8/x86_64/
-          - https://yum.theforeman.org/plugins/nightly/el8/x86_64/
       rhel-9:
         additional_modules: "foreman-devel:el9"
         additional_repos:


### PR DESCRIPTION
This PR removes the obsolete rhel-8 target from the Packit config

🤖 Generated with [Claude Code](https://claude.com/claude-code)