### PR TITLE
Add gce.json template for the API

### DIFF
--- a/app/views/api/v2/compute_resources/gce.json.rabl
+++ b/app/views/api/v2/compute_resources/gce.json.rabl
@@ -1,0 +1,1 @@
+attributes :email, :zone, :project, :key_path

--- a/lib/foreman_google/engine.rb
+++ b/lib/foreman_google/engine.rb
@@ -10,6 +10,12 @@ module ForemanGoogle
       end
     end
 
+    initializer 'foreman_google.add_rabl_view_path' do
+      Rabl.configure do |config|
+        config.view_paths << ForemanGoogle::Engine.root.join('app', 'views')
+      end
+    end
+
     initializer 'foreman_google.register_plugin', before: :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_google do
         requires_foreman '>= 3.13.0'


### PR DESCRIPTION
This was not copied over in the original "move GCE support out of core", but was recently removed from core [1], resulting in errors like

    Cannot find rabl template 'api/v2/compute_resources/gce.json' within registered …

[1] https://github.com/theforeman/foreman/commit/b1f397d6119ab7cc4f30eef1f4813d64e423a7cf