### PR TITLE
Fix GCE images pagination listing issue

### DIFF
--- a/app/lib/foreman_google/google_compute_adapter.rb
+++ b/app/lib/foreman_google/google_compute_adapter.rb
@@ -148,8 +148,7 @@ module ForemanGoogle
 
     def list_images(project, **opts)
       resource_name = 'images'
-      response = resource_client(resource_name).list(project: project, **opts).response
-      response.items
+      resource_client(resource_name).list(project: project, **opts).to_a
     rescue ::Google::Cloud::Error => e
       raise Foreman::WrappedException.new(e, 'Cannot list Google resource %s', resource_name)
     end


### PR DESCRIPTION
**Problem:**

The Google Cloud list API returns results in batches. The previous implementation used `.response.items` , which only returned the first 500 images (resources) .

As a result, any resources beyond the first 500 were not returned by the adapter, leading to missing images during lookup and validation.

**Solution:**

The `to_a` call retrieves the complete set of results returned by the API instead of limiting the response to the first 500 resources.

This change ensures that all images available in the GCP project are correctly fetched and processed by the adapter.