### PR TITLE
[DRAFT] Update Google Compute dependencies for Ruby 3 packaging

### DIFF
--- a/foreman_google.gemspec
+++ b/foreman_google.gemspec
@@ -11,15 +11,18 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/theforeman/foreman_google'
   s.summary     = 'Google Compute Engine plugin for the Foreman'
   s.description = 'Google Compute Engine plugin for the Foreman'
-  s.required_ruby_version = '>= 2.7', '< 4'
+  s.required_ruby_version = '>= 3.0', '< 4'
 
   s.files = Dir['{app,config,db,lib,locale,webpack}/**/*'] + ['LICENSE', 'Rakefile', 'README.md', 'package.json']
   s.test_files = Dir['test/**/*'] + Dir['webpack/**/__tests__/*.js']
 
-  # Pin Google versions to avoid breaking changes
-  # Never versions with google-protobuf > 3.25.4
-  # are failing with `undefined method 'build'` error
-  s.add_dependency 'google-apis-compute_v1', '0.54.0'
-  s.add_dependency 'google-cloud-compute', '0.5.0'
-  s.add_dependency 'google-protobuf', '3.24.3'
+  # Use the newest google-cloud-compute line that still works with Ruby 3.0,
+  # which remains the safe baseline for EL9 packaging.
+  s.add_dependency 'google-cloud-compute', '1.15.0'
+  # Keep the versioned client below 2.22.0 so resolution stays within the
+  # Ruby-3.0-compatible line even when the builder runs a newer Ruby.
+  s.add_dependency 'google-cloud-compute-v1', '>= 2.15.0', '< 2.22.0'
+  # Keep protobuf pinned to the last known version before DescriptorPool#build
+  # compatibility issues were reported with older generated clients.
+  s.add_dependency 'google-protobuf', '3.25.4'
 end

--- a/lib/foreman_google.rb
+++ b/lib/foreman_google.rb
@@ -1,3 +1,5 @@
+require 'google/cloud/compute'
+require 'google/cloud/compute/v1'
 require 'foreman_google/engine'
 
 module ForemanGoogle

--- a/test/unit/google_extensions/attached_disk_test.rb
+++ b/test/unit/google_extensions/attached_disk_test.rb
@@ -1,7 +1,22 @@
 require 'test_google_helper'
+require 'rbconfig'
 
 module GoogleExtensions
   class AttachedDiskTest < GoogleTestCase
+    describe 'plugin loading' do
+      it 'loads AttachedDisk through the plugin entrypoint' do
+        helper = ForemanGoogle::Engine.root.join('test', 'test_google_helper').to_s
+        script = <<~RUBY
+          require 'bundler/setup'
+          require "#{helper}"
+          require 'foreman_google'
+          abort 'missing AttachedDisk' unless defined?(Google::Cloud::Compute::V1::AttachedDisk)
+        RUBY
+
+        assert system({ 'BUNDLE_GEMFILE' => ForemanGoogle::Engine.root.join('Gemfile').to_s }, RbConfig.ruby, '-e', script)
+      end
+    end
+
     describe 'insert_attrs' do
       it 'with source image' do
         disk = Google::Cloud::Compute::V1::AttachedDisk.new(source: 'source-image')


### PR DESCRIPTION
Move foreman_google to the newest google-cloud-compute line that stays compatible with Ruby 3.0 so EL9/EL10 packaging can adopt a Faraday-2-capable Google client stack. Tighten the gemspec Ruby floor to 3.0 and add regression coverage for the explicit v1 require so AttachedDisk remains available with the newer gems.